### PR TITLE
[fix] pseudo-elements with double colon

### DIFF
--- a/src/sass/base/_defaults.sass
+++ b/src/sass/base/_defaults.sass
@@ -9,7 +9,7 @@
 *
   box-sizing: border-box
 
-:before, :after
+::before, ::after
   box-sizing: inherit
 
 

--- a/src/sass/lib/mixins/_clearfix.sass
+++ b/src/sass/lib/mixins/_clearfix.sass
@@ -3,12 +3,12 @@
 //============================================
 
 =clearfix
-  &:after,
-  &:before
+  &::after,
+  &::before
     content: ""
     display: table
 
-  &:after
+  &::after
     clear: both
 
 // Alias


### PR DESCRIPTION
Sass linting asks for double color in front of pseudo-elements. This commit addresses this request. 
