### PR TITLE
[add] glob for json concatenation

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -61,7 +61,7 @@ module.exports = {
     src: src + '/html',
     dest: dest + '/',
     glob: '**/*.{html,json}',
-    data: src + '/html/data/global.json',
+    data: src + '/html/data/*.json',
     extensions: ['html', 'json'],
     excludeFolders: ['layouts', 'shared', 'macros', 'data']
   },

--- a/gulpfile.js/tasks/html.js
+++ b/gulpfile.js/tasks/html.js
@@ -1,17 +1,26 @@
 'use strict';
 
 var config       = require('../config').html;
-var browserSync  = require('browser-sync')
-var data         = require('gulp-data')
-var gulp         = require('gulp')
+var browserSync  = require('browser-sync');
+var data         = require('gulp-data');
+var gulp         = require('gulp');
 var handleErrors = require('../util/handleErrors');
-var path         = require('path')
-var render       = require('gulp-nunjucks-render')
-var fs           = require('fs')
+var path         = require('path');
+var render       = require('gulp-nunjucks-render');
+var fs           = require('fs');
+var _            = require('lodash');
+var glob         = require("glob");
 
-var getData = function(file) {
-  var dataPath = path.resolve(config.data)
-  return JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+var getData = function() {
+  let data = {};
+
+  let files = glob.sync(config.data)
+  files.forEach((el) => {
+    const dataPath = path.resolve(el);
+    _.extend(data, JSON.parse(fs.readFileSync(dataPath, 'utf8')))
+  });
+
+  return data;
 }
 
 var exclude = path.normalize('!**/{' + config.excludeFolders.join(',') + '}/**');

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cssnano": "^3.6.2",
     "del": "2.2.0",
     "eslint-plugin-babel": "^3.3.0",
+    "glob": "^7.1.1",
     "gulp": "^3.9.1",
     "gulp-changed": "^1.3.0",
     "gulp-data": "^1.2.1",


### PR DESCRIPTION
I add `glob` that allows to concatenate multiple `.json` files instead of defining the path in the `gulpfile.js/config.js`. Would be even cooler to add a control that prompts an error in the terminal if the same value is defined in multiple files.
